### PR TITLE
Signup page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,13 +4,19 @@ import { Route, Switch } from 'react-router-dom';
 import Home from './containers/Home';
 import Login from './containers/Login';
 import NotFound from './containers/NotFound';
+import Signup from './containers/Signup';
 
 import AppliedRoute from './components/AppliedRoute';
 
 export default ({ childProps }) => (
     <Switch>
+        {/* use exact to just apply to exact url 
+            childProps coming from what is being passed from parent
+            component
+        */}
         <AppliedRoute path="/" exact component={Home} props={childProps} />
         <AppliedRoute path="/login" exact component={Login} props={childProps} />
+        <AppliedRoute path="/signup" exact component={Signup} props={childProps} />
         {/* Finally, catch all unmatched routes */}
         <Route component={NotFound} />
     </Switch>

--- a/src/containers/Signup.css
+++ b/src/containers/Signup.css
@@ -1,0 +1,16 @@
+@media all and (min-width: 480px) {
+  .Signup {
+    padding: 60px 0;
+  }
+
+  .Signup form {
+    margin: 0 auto;
+    max-width: 320px;
+  }
+}
+
+.Signup form span.help-block {
+  font-size: 14px;
+  padding-bottom: 10px;
+  color: #999;
+}

--- a/src/containers/Signup.js
+++ b/src/containers/Signup.js
@@ -1,0 +1,134 @@
+import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+import {
+  HelpBlock,
+  FormGroup,
+  FormControl,
+  ControlLabel,
+} from 'react-bootstrap';
+import LoaderButton from '../components/LoaderButton';
+import './Signup.css';
+
+class Signup extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isLoading: false,
+      username: '',
+      password: '',
+      confirmPassword: '',
+      confirmationCode: '',
+      newUser: null,
+    };
+  }
+
+  validateForm() {
+    return this.state.username.length > 0
+      && this.state.password.length > 0
+      && this.state.password === this.state.confirmPassword;
+  }
+
+  validateConfirmationForm() {
+    return this.state.confirmationCode.length > 0;
+  }
+
+  handleChange = (event) => {
+    this.setState({
+      [event.target.id]: event.target.value
+    });
+  }
+
+  handleSubmit = async (event) => {
+    event.preventDefault();
+
+    this.setState({ isLoading: true });
+
+    this.setState({ newUser: 'test' });
+
+    this.setState({ isLoading: false});
+  }
+
+  handleConfirmationSubmit = async (event) => {
+    event.preventDefault();
+
+    this.setState({ isLoading: true });
+  }
+
+
+  renderConfirmationForm() {
+    return (
+      <form onSubmit={this.handleConfirmationSubmit}>
+        <FormGroup controlId="confirmationCode" bsSize="large">
+          <ControlLabel>Confirmation Code</ControlLabel>
+          <FormControl 
+            autoFocus
+            type="tel"
+            value={this.state.confirmationCode}
+            onChange={this.handleChange} />
+          <HelpBlock>Please check your email for the code.</HelpBlock>
+        </FormGroup>
+        <LoaderButton 
+          block
+          bsSize="large"
+          disabled={ ! this.validateConfirmationForm() }
+          type="submit"
+          isLoading={this.state.isLoading}
+          text="Verify"
+          loadingText="Verifying..." />
+      </form>
+    );
+  }
+
+  renderForm() {
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <FormGroup controlId="username" bsSize="large">
+          <ControlLabel>Email</ControlLabel>
+          <FormControl 
+            autoFocus
+            type="email"
+            value={this.state.username}
+            onChange={this.handleChange} />
+        </FormGroup>
+        <FormGroup controlId="password" bsSize="large">
+          <ControlLabel>Password</ControlLabel>
+          <FormControl 
+            type="password"
+            value={this.state.password}
+            onChange={this.handleChange} />
+        </FormGroup>
+        <FormGroup controlId="confirmPassword" bsSize="large">
+          <ControlLabel>Confirm Password</ControlLabel>
+          <FormControl 
+            type="password"
+            value={this.state.confirmPassword}
+            onChange={this.handleChange} />
+        </FormGroup>
+        <LoaderButton 
+          block
+          bsSize="large"
+          disabled={ ! this.validateForm() }
+          type="submit"
+          isLoading={this.state.isLoading}
+          text="Signup"
+          loadingText="Signing up..." />
+      </form>
+    );
+  }
+
+  // conditionally render 2 forms above
+  // depending if the user is a new user or not
+  render() {
+    return (
+      <div className="Signup">
+        { this.state.newUser === null
+          ? this.renderForm()
+          : this.renderConfirmationForm() }
+      </div>
+    );
+  }
+
+}
+
+export default withRouter(Signup);


### PR DESCRIPTION
A quick note on the signup flow here. If the user refreshes their page at the confirm step, they won’t be able to get back and confirm that account. It forces them to create a new account instead. We are keeping things intentionally simple here but you can fix this by creating a separate page that handles the confirm step based on the email address. [Here ](http://docs.aws.amazon.com/cognito/latest/developerguide/using-amazon-cognito-user-identity-pools-javascript-examples.html#using-amazon-cognito-identity-user-pools-javascript-example-confirming-user)is some sample code that you can use to confirm an unauthenticated user.